### PR TITLE
Prevent Rx/Tx clash by preventing receive_packet from reading while s…

### DIFF
--- a/sx127x.py
+++ b/sx127x.py
@@ -419,6 +419,10 @@ class SX127x:
         return True
 
     def received_packet(self, size = 0):
+        # Don't check Rx until Tx is done
+        if self._lock:
+            return not self._lock
+
         irq_flags = self.get_irq_flags()
 
         self.implicit_header_mode(size > 0)


### PR DESCRIPTION
…elf._lock is true

While using the uPyLoRaWAN with an asynchronous web server, [MicroWebSrv2](https://github.com/jczic/MicroWebSrv2), I noticed that my Tx data was being corrupted which I believe is due to `received_packet` resetting the FiFo address (?). To prevent `received_packet` from executing during a Tx I added a check to see if a lock has been set.

Example web server / lora code
```python
@WebRoute(POST, '/message')
def RequestHandler(microWebSrv2, request):
    # Send message over Lora
    lora.println('1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz')
    request.Response.ReturnOk()

if __name__ == '__main__':
    # Instanciates the MicroWebSrv2 class, 
    mws2 = MicroWebSrv2()
    # For embedded MicroPython, use a very light configuration,
    mws2.SetEmbeddedConfig()
    # Starts the server as easily as possible in managed mode,
    mws2.StartManaged()
    # Main program loop until keyboard interrupt,
    try:
        while mws2.IsRunning:
            if lora.received_packet():
                lora.blink_led()
                payload = lora.read_payload()
                print('lora recieved: ', payload)
                ...
                
    except KeyboardInterrupt:
        pass

    # End,
    mws2.Stop()
```
Full code: https://github.com/jsonpoindexter/ulora-ttgo-chat/blob/98c125402dc09cda549f147c66f7c66e4dac1646/main.py

When no lock is implemented in `received_packet()` the payload would be corrupted when receiving it on another device:
```python 
lora recieved: b'uvwxyz1234567890abcdefghijklmnopqrstuvwxyz\xaf\x19\x04^\x89\x07\xbc\xb2vC\x95\x8a\x1f\xc5\xba\xb9\xd9\x15\t@\x90\xb9\x98\xeesa-\xb0n\xdd'
```
When the transmitting device had `if lora.received_packet():` removed/commented out the payload would be received intact.
